### PR TITLE
No sqlite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"file-stream-rotator": "^1.0.0",
 				"follow-redirects": "1.15.6",
 				"fs-extra": "11.1.1",
+				"handlebars": "^4.7.8",
 				"hpagent": "1.2.0",
 				"react-markdown": "^9.0.1",
 				"remark-gfm": "^4.0.0",
@@ -12092,6 +12093,26 @@
 			"integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
 			"dev": true
 		},
+		"node_modules/handlebars": {
+			"version": "4.7.8",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"dependencies": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.2",
+				"source-map": "^0.6.1",
+				"wordwrap": "^1.0.0"
+			},
+			"bin": {
+				"handlebars": "bin/handlebars"
+			},
+			"engines": {
+				"node": ">=0.4.7"
+			},
+			"optionalDependencies": {
+				"uglify-js": "^3.1.4"
+			}
+		},
 		"node_modules/has-bigints": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -20852,6 +20873,18 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/uglify-js": {
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.18.0.tgz",
+			"integrity": "sha512-SyVVbcNBCk0dzr9XL/R/ySrmYf0s372K6/hFklzgcp2lBFyXtw4I7BOdDjlLhE1aVqaI/SHWXWmYdlZxuyF38A==",
+			"optional": true,
+			"bin": {
+				"uglifyjs": "bin/uglifyjs"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -21925,6 +21958,11 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
 		},
 		"node_modules/wp-error": {
 			"version": "1.3.0",
@@ -31360,6 +31398,18 @@
 			"integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
 			"dev": true
 		},
+		"handlebars": {
+			"version": "4.7.8",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"requires": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.2",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4",
+				"wordwrap": "^1.0.0"
+			}
+		},
 		"has-bigints": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -37764,6 +37814,12 @@
 			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"dev": true
 		},
+		"uglify-js": {
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.18.0.tgz",
+			"integrity": "sha512-SyVVbcNBCk0dzr9XL/R/ySrmYf0s372K6/hFklzgcp2lBFyXtw4I7BOdDjlLhE1aVqaI/SHWXWmYdlZxuyF38A==",
+			"optional": true
+		},
 		"unbox-primitive": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -38541,6 +38597,11 @@
 			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true,
 			"optional": true
+		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
 		},
 		"wp-error": {
 			"version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
 		"file-stream-rotator": "^1.0.0",
 		"follow-redirects": "1.15.6",
 		"fs-extra": "11.1.1",
+		"handlebars": "^4.7.8",
 		"hpagent": "1.2.0",
 		"react-markdown": "^9.0.1",
 		"remark-gfm": "^4.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,7 @@ async function appBoot() {
 	function setupIpc() {
 		for ( const [ key, handler ] of Object.entries( ipcHandlers ) ) {
 			if ( typeof handler === 'function' && key !== 'logRendererMessage' ) {
+				console.log( key );
 				ipcMain.handle( key, function ( event, ...args ) {
 					try {
 						validateIpcSender( event );

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -397,6 +397,11 @@ export async function deleteSite( event: IpcMainInvokeEvent, id: string, deleteF
 	if ( ! server ) {
 		throw new Error( 'Site not found.' );
 	}
+
+	// Delete DB
+	const service = new MySQLService();
+	await service.deleteDatabaseServer( server );
+
 	const userData = await loadUserData();
 	await server.delete();
 	try {
@@ -406,8 +411,9 @@ export async function deleteSite( event: IpcMainInvokeEvent, id: string, deleteF
 		}
 	} catch ( error ) {
 		/* We want to exit gracefully if the there is an error deleting the site files */
-		Sentry.captureException( error );
+		Sentry.captureException(error);
 	}
+
 	const newSites = userData.sites.filter( ( site ) => site.id !== id );
 	const newUserData = { ...userData, sites: newSites };
 	await saveUserData( newUserData );

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -28,6 +28,7 @@ interface StoppedSiteDetails {
 		supportsWidgets: boolean;
 		supportsMenus: boolean;
 	};
+	mysql?: MySQLConfig;
 }
 
 interface StartedSiteDetails extends StoppedSiteDetails {
@@ -92,4 +93,29 @@ interface Window {
 interface WpcomNetworkError extends Error {
 	code: string;
 	status: number;
+}
+
+/**
+ * This represents the MySQL configuration for a site.
+ * It will be stored with the appropriate site in the userdata.
+ */
+interface MySQLConfig {
+	// Instance details
+	instanceId: string;
+	instanceDir: string;
+	dataDir: string;
+	version: string;
+
+	// Connection
+	host: string;
+	port: number;
+
+	// Root user
+	rootUsername: string;
+	rootPassword: string;
+
+	// WP user
+	wpUsername: string;
+	wpPassword: string;
+	wpDatabase: string;
 }

--- a/src/lib/mysql.ts
+++ b/src/lib/mysql.ts
@@ -1,0 +1,10 @@
+import path from 'path';
+
+class MySQLService {
+
+	constructor() {
+		const mysqlBinPath = path.join( __dirname, '..', 'bin', 'mysql' );
+	}
+
+
+}

--- a/src/lib/mysql/process-manager.ts
+++ b/src/lib/mysql/process-manager.ts
@@ -66,7 +66,7 @@ class MySQLProcessManager {
 	public async stopProcess( instanceId: string ) {
 		const proc = this.processes.get( instanceId );
 		if ( ! proc ) {
-			throw new Error( `MySQL process for instance ${ instanceId } not found` );
+			return;
 		}
 
 		return new Promise( ( resolve, reject ) => {

--- a/src/lib/mysql/process-manager.ts
+++ b/src/lib/mysql/process-manager.ts
@@ -1,0 +1,179 @@
+import { ChildProcess, spawn } from 'child_process';
+import path from 'path';
+import fs from 'fs-extra';
+import { execAsync } from './utils';
+import versions from './versions';
+
+class MySQLProcessManager {
+	private static instance: MySQLProcessManager;
+	private static exitHandlerBound = false;
+	private processes: Map< string, ChildProcess > = new Map();
+	private configs: Map< string, MySQLConfig > = new Map();
+
+	private constructor() {
+		// Private constructor to prevent instantiation
+		if ( ! MySQLProcessManager.exitHandlerBound ) {
+			this.bindExitHandlers();
+			MySQLProcessManager.exitHandlerBound = true;
+		}
+	}
+
+	/**
+	 * Get the singleton instance of the MySQLProcessManager.
+	 * @returns MySQLProcessManager
+	 */
+	public static getInstance() {
+		if ( ! MySQLProcessManager.instance ) {
+			MySQLProcessManager.instance = new MySQLProcessManager();
+		}
+
+		return MySQLProcessManager.instance;
+	}
+
+	/**
+	 * Start a new MySQL process for the given configuration.
+	 * @param config
+	 */
+	public async startProcess( config: MySQLConfig ) {
+		if ( this.processes.has( config.instanceId ) ) {
+			throw new Error( `MySQL process for site ${ config.instanceId } already started` );
+		}
+
+		await fs.ensureDir( config.dataDir );
+		const version = versions[ config.version ];
+
+		const mysqld = version.mysqldBinPath;
+		const args = [ `--defaults-file=${ path.join( config.instanceDir, 'my.cnf' ) }` ];
+
+		const proc = spawn( mysqld, args, {
+			stdio: 'inherit',
+		} );
+
+		this.processes.set( config.instanceId, proc );
+		this.configs.set( config.instanceId, config );
+
+		proc.on( 'exit', ( code ) => {
+			console.log( `MySQL process for site ${ config.instanceId } exited with code ${ code }` );
+			this.processes.delete( config.instanceId );
+			this.configs.delete( config.instanceId );
+		} );
+	}
+
+	/**
+	 * Stop the MySQL process for the given instance.
+	 * @param instanceId
+	 */
+	public async stopProcess( instanceId: string ) {
+		const proc = this.processes.get( instanceId );
+		if ( ! proc ) {
+			throw new Error( `MySQL process for instance ${ instanceId } not found` );
+		}
+
+		return new Promise( ( resolve, reject ) => {
+			console.log( `Stopping MySQL process for site ${ instanceId }` );
+			proc.on( 'exit', resolve );
+			proc.on( 'error', reject );
+			proc.kill( 'SIGTERM' );
+		} ).then( () => {
+			this.processes.delete( instanceId );
+			this.configs.delete( instanceId );
+		} );
+	}
+
+	/**
+	 * Restart the MySQL process for the given instance.
+	 * @param instanceId
+	 */
+	public async restartProcess( instanceId: string ) {
+		await this.stopProcess( instanceId );
+		const config = this.configs.get( instanceId );
+		if ( ! config ) {
+			throw new Error( `MySQL config for site ${ instanceId } not found` );
+		}
+		await this.startProcess( config );
+	}
+
+	/**
+	 * Stop all MySQL processes.
+	 */
+	public async stopAllProcesses() {
+		const stopPromises = [];
+		console.log( 'Stopping all MySQL processes' );
+		for ( const [ instanceId ] of this.processes ) {
+			stopPromises.push( this.stopProcess( instanceId ) );
+		}
+
+		await Promise.all( stopPromises );
+	}
+
+	/**
+	 * Check if a MySQL process is running for the given instance.
+	 * @param instanceId
+	 */
+	public async hasProcess( instanceId: string ) {
+		return this.processes.has( instanceId );
+	}
+
+	/**
+	 * Checks whether the database is ready to accept connections.
+	 * If not, it will retry a few times with a delay in between.
+	 * Finally, if the database is not in a ready state after the
+	 * retries, it will return false.
+	 *
+	 * @param config MySQLConfig
+	 */
+	public async waitForDatabase( config: MySQLConfig ) {
+		const version = versions[ config.version ];
+		const mysql = version.mysqladminBinPath;
+		const cfgPath = path.join( config.instanceDir, 'my.cnf' );
+		const args = [ `--defaults-file=${ cfgPath }`, '--password=', 'ping' ];
+
+		const maxTries = 10;
+		const delayMs = 1000; // 1 second delay between attempts
+		for ( let attempt = 1; attempt <= maxTries; attempt++ ) {
+			try {
+				const result = await execAsync( mysql, args );
+				if ( result.code === 0 ) {
+					return true;
+				}
+			} catch ( error ) {
+				console.log( `Attempt ${ attempt } failed: ${ error }` );
+			}
+
+			if ( attempt < maxTries ) {
+				await this.delay( delayMs );
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Delay for a given number of milliseconds.
+	 * @param ms
+	 * @private
+	 */
+	private async delay( ms: number ) {
+		return new Promise( ( resolve ) => setTimeout( resolve, ms ) );
+	}
+
+	/**
+	 * Bind exit handlers to stop all processes when the process exits.
+	 * @private
+	 */
+	private bindExitHandlers() {
+		process.on( 'exit', async () => {
+			await this.stopAllProcesses();
+		} );
+
+		process.on( 'SIGINT', async () => {
+			await this.stopAllProcesses();
+		} );
+
+		process.on( 'uncaughtException', async ( error ) => {
+			console.error( 'Uncaught exception:', error );
+			await this.stopAllProcesses();
+		} );
+	}
+}
+
+export { MySQLProcessManager };

--- a/src/lib/mysql/provisioner.ts
+++ b/src/lib/mysql/provisioner.ts
@@ -1,0 +1,200 @@
+import fs from 'fs';
+import path from 'path';
+import { ensureDir } from 'fs-extra';
+import Handlebars from 'handlebars';
+import { SiteServer } from '../../site-server';
+import { MySQLProcessManager } from './process-manager';
+import { execAsync } from './utils';
+import versions from './versions';
+import { decodePassword } from '../passwords';
+
+/**
+ * Provision a new MySQL database for the new site.
+ *
+ * The role of the provisioner is to create the necessary directories and configuration files
+ * for the MySQL instance, and to initialize the database with the necessary tables and data.
+ *
+ */
+class MySQLProvisioner {
+	constructor(
+		private config: MySQLConfig,
+		private server: SiteServer
+	) {}
+
+	/**
+	 * Provision a new MySQL database for the new site.
+	 *
+	 * @todo We need some sort of logging mechanism?
+	 */
+	async provisionDatabase() {
+		console.log( 'Provisioning database' );
+		await this.createDataDirAndConfig();
+		await this.initializeDatabase().catch( ( err ) => {
+			console.error( 'Error initializing database', err );
+		} );
+
+		// Start the MySQL server.
+		const pm = MySQLProcessManager.getInstance();
+		await pm.startProcess( this.config );
+
+		// Wait for the database to start.
+		const started = await pm.waitForDatabase( this.config );
+
+		if ( ! started ) {
+			throw new Error( 'Could not start the database' );
+		}
+
+		// Prepare the users and database.
+		await this.alterRootUser();
+		await this.createWPDatabase();
+		await this.createWPDatabaseUser();
+		await this.grantWPDatabaseUser();
+
+		// @todo populate the wp database wp core install?
+		// wp config create?
+
+		const dbHost = `${ this.config.host }:${ this.config.port }`;
+		const adminPass = decodePassword( this.server.details.adminPassword || 'password' );
+		console.log("Created site with pass: ", adminPass);
+		await this.server.executeWpCliCommand( `config set DB_NAME ${ this.config.wpDatabase }` );
+		await this.server.executeWpCliCommand( `config set DB_USER ${ this.config.wpUsername }` );
+		await this.server.executeWpCliCommand( `config set DB_PASSWORD ${ this.config.wpPassword }` );
+		await this.server.executeWpCliCommand( `config set DB_HOST ${ dbHost }` );
+
+		const { stdout, stderr } = await this.server.executeWpCliCommand(
+			`core install --url="http://localhost:${ this.server.details.port }" --title="${ this.server.details.name }" --admin_user=admin --admin_password="${ adminPass }" --admin_email=studio@example.com`
+		);
+
+		console.log( 'WP Core Install', stdout, stderr );
+	}
+
+	private async createDataDirAndConfig() {
+		console.log( 'Creating data dir and config' );
+		console.log( 'Creating ' + this.config.dataDir );
+		await ensureDir( this.config.dataDir );
+		await fs.promises.chmod( this.config.dataDir, 0o755 );
+		await this.createCnf( this.config );
+	}
+
+	/**
+	 * Initialize the database with the necessary tables and data.
+	 * @private
+	 */
+	private async initializeDatabase() {
+		const cnfPath = path.join( this.config.instanceDir, 'my.cnf' );
+		const version = versions[ this.config.version ];
+		const mysqldPath = version.mysqldBinPath;
+
+		const result = await execAsync( mysqldPath, [
+			'--defaults-file=' + cnfPath,
+			'--initialize-insecure',
+		] );
+
+		if ( result.code !== 0 ) {
+			throw new Error( `Failed to initialize database: ${ result.stderr }` );
+		}
+	}
+
+	/**
+	 * Create the WordPress database
+	 * @private
+	 */
+	private async createWPDatabase() {
+		const version = versions[ this.config.version ];
+		const result = await execAsync( version.mysqlBinPath, [
+			`--defaults-file=${ path.join( this.config.instanceDir, 'my.cnf' ) }`,
+			'-e',
+			`CREATE DATABASE ${ this.config.wpDatabase }`,
+		] );
+
+		if ( result.code !== 0 ) {
+			throw new Error( `Failed to create database: ${ result.stderr }` );
+		}
+	}
+
+	/**
+	 * Set the password for the root user
+	 *
+	 * @private
+	 */
+	private async alterRootUser() {
+		// ALTER
+		const version = versions[ this.config.version ];
+		const result = await execAsync( version.mysqlBinPath, [
+			`--defaults-file=${ path.join( this.config.instanceDir, 'my.cnf' ) }`,
+			'--password=',
+			'-e',
+			`ALTER USER 'root'@'localhost' IDENTIFIED BY '${ this.config.rootPassword }'`,
+		] );
+
+		if ( result.code !== 0 ) {
+			throw new Error( `Failed to change the root user: ${ result.stderr }` );
+		}
+	}
+
+	/**
+	 * Create a user for the database
+	 * @private
+	 */
+	private async createWPDatabaseUser() {
+		console.log( 'Creating database user' );
+		const version = versions[ this.config.version ];
+		const result = await execAsync( version.mysqlBinPath, [
+			`--defaults-file=${ path.join( this.config.instanceDir, 'my.cnf' ) }`,
+			'-e',
+			`CREATE USER '${ this.config.wpUsername }'@'127.0.0.1' IDENTIFIED BY '${ this.config.wpPassword }'`,
+		] );
+
+		if ( result.code !== 0 ) {
+			throw new Error( `Failed to create database user: ${ result.stderr }` );
+		}
+	}
+
+	/**
+	 * Grant the user access to the database
+	 * @todo Line is too long, fix it.
+	 * @private
+	 */
+	private async grantWPDatabaseUser() {
+		console.log( 'Granting database user' );
+		const version = versions[ this.config.version ];
+		const result = await execAsync( version.mysqlBinPath, [
+			`--defaults-file=${ path.join( this.config.instanceDir, 'my.cnf' ) }`,
+			'-e',
+			`GRANT ALL PRIVILEGES ON ${ this.config.wpDatabase }.* TO '${ this.config.wpUsername }'@'127.0.0.1' WITH GRANT OPTION; FLUSH PRIVILEGES;`,
+		] );
+
+		if ( result.code !== 0 ) {
+			throw new Error( `Failed to grant database user: ${ result.stderr }` );
+		}
+	}
+
+	private async createCnf( config: MySQLConfig ) {
+		console.log( 'Creating my.cnf' );
+
+		const version = versions[ config.version ];
+		const outputPath = path.join( config.instanceDir, 'my.cnf' );
+		const templateContent = fs.readFileSync( version.mysqlCnfTemplatePath, 'utf-8' );
+
+		// Process the template with handlebars
+		const template = Handlebars.compile( templateContent );
+
+		const output = template( {
+			os: {
+				windows: false,
+			},
+			disableMysqlx: true,
+			port: config.port,
+			bindAddress: config.host,
+			dataDir: config.dataDir,
+			socket: path.join( config.instanceDir, 'mysql.sock' ),
+			clientAddress: config.host,
+		} );
+
+		await fs.promises.writeFile( outputPath, output, 'utf-8' );
+
+		console.log( 'Configuration stored at ' + outputPath );
+	}
+}
+
+export { MySQLProvisioner };

--- a/src/lib/mysql/service.ts
+++ b/src/lib/mysql/service.ts
@@ -1,0 +1,152 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import http from 'http';
+import * as net from 'net';
+import path from 'path';
+import { SiteServer } from '../../site-server';
+import { loadUserData } from '../../storage/user-data';
+import { portFinder } from '../port-finder';
+import { MySQLProcessManager } from './process-manager';
+import { MySQLProvisioner } from './provisioner';
+
+/**
+ * Service class for MySQL
+ * Manages the MySQL process and provisions new databases.
+ * @todo maybe pass a configuration object instead of individual params. Would be an object with installation details, not same as MySQLConfig;
+ */
+class MySQLService {
+	/**
+	 * Provisions a new MySQL database for the site and returns the configuration to be stored
+	 * with the site.
+	 * @param server
+	 * @param mysqlInstancesPath
+	 * @param version
+	 */
+	async provisionDatabase(
+		server: SiteServer,
+		mysqlInstancesPath: string,
+		version: string
+	): Promise< MySQLConfig > {
+		// We can't use the siteId as directory because it would result in a too long
+		// path for the mysql socket. We need to generate a random directory name shorter directory.
+		const instanceId = await this.randomDirectoryId( mysqlInstancesPath );
+		const rootDir = path.join( mysqlInstancesPath, instanceId );
+		const nextPort = await this.getNextPort();
+
+		if ( nextPort === 0 ) {
+			throw new Error( 'Could not find an available port for MySQL' );
+		}
+
+		const instanceConfig: MySQLConfig = {
+			instanceId: instanceId,
+			dataDir: path.join( rootDir, 'data' ),
+			instanceDir: rootDir,
+			host: '127.0.0.1',
+			port: nextPort,
+			rootPassword: 'root',
+			rootUsername: 'root',
+			wpDatabase: 'wordpress',
+			wpPassword: 'password',
+			wpUsername: 'wp_user',
+			version,
+		};
+
+		const provisioner = new MySQLProvisioner( instanceConfig, server );
+		await provisioner.provisionDatabase();
+
+		return instanceConfig;
+	}
+
+	async startDatabaseServer( server: SiteServer ) {
+		if ( ! server.details.mysql ) {
+			return;
+		}
+		const pm = MySQLProcessManager.getInstance();
+		await pm.startProcess( server.details.mysql );
+
+		return await pm.waitForDatabase( server.details.mysql );
+	}
+
+	async stopDatabaseServer( server: SiteServer ) {
+		if ( ! server.details.mysql ) {
+			return;
+		}
+		const pm = MySQLProcessManager.getInstance();
+		return await pm.stopProcess( server.details.mysql.instanceId );
+	}
+
+	async deleteDatabaseServer( server: SiteServer ) {
+		// Stop processes
+		// Delete data directory
+
+		if ( ! server.details.mysql ) {
+			return;
+		}
+
+
+	}
+
+	/**
+	 * Generates a random directory name that does not already exist in the rootDir.
+	 * @param rootDir
+	 * @private
+	 */
+	private async randomDirectoryId( rootDir: string ) {
+		let dirName;
+		let dirPath;
+		do {
+			// Generate a 6-character hexadecimal directory name to keep it short
+			dirName = crypto.randomBytes( 3 ).toString( 'hex' );
+			dirPath = path.join( rootDir, dirName );
+		} while ( fs.existsSync( dirPath ) );
+
+		return dirName;
+	}
+
+	/**
+	 * Try to get the next available port for MySQL
+	 * @private
+	 */
+	private async getNextPort() {
+		const { sites } = await loadUserData();
+		const takenPorts = sites.map( ( site ) => site.mysql?.port ).filter( ( port ) => port );
+
+		for ( let port = 11000; port < 12000; port++ ) {
+			if ( ! takenPorts.includes( port ) && ( await this.checkPortIsFree( port ) ) ) {
+				return port;
+			}
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Check if a port is free on 127.0.0.1
+	 * @param port
+	 * @private
+	 */
+	private checkPortIsFree( port: number ) {
+		interface ExtendedError extends Error {
+			code?: string;
+		}
+
+		return new Promise( ( resolve ) => {
+			const server = net.createServer();
+
+			server.once( 'error', ( err: ExtendedError ) => {
+				if ( err.code === 'EADDRINUSE' ) {
+					resolve( false );
+				}
+			} );
+
+			server.once( 'listening', () => {
+				server.close();
+				resolve( true );
+			} );
+
+			server.listen( port, '127.0.0.1' );
+		} );
+	}
+}
+
+export { MySQLService };

--- a/src/lib/mysql/service.ts
+++ b/src/lib/mysql/service.ts
@@ -83,7 +83,11 @@ class MySQLService {
 			return;
 		}
 
+		const pm = MySQLProcessManager.getInstance();
+		await pm.stopProcess( server.details.mysql.instanceId );
 
+		// Delete files
+		await fs.promises.rm( server.details.mysql.instanceDir, { recursive: true } );
 	}
 
 	/**

--- a/src/lib/mysql/utils.ts
+++ b/src/lib/mysql/utils.ts
@@ -1,0 +1,52 @@
+import { spawn, SpawnOptions, execFile } from 'child_process';
+
+interface ExecResult {
+	stdout: string;
+	stderr: string;
+	code: number | null;
+}
+
+function execAsync(
+	command: string,
+	args: string[],
+	options: SpawnOptions = {}
+): Promise< ExecResult > {
+	return new Promise( ( resolve, reject ) => {
+		const process = spawn( command, args, { ...options, stdio: 'pipe' } );
+		let stdout = '';
+		let stderr = '';
+
+		process.stdout?.on( 'data', ( data ) => {
+			stdout += data.toString();
+		} );
+
+		process.stderr?.on( 'data', ( data ) => {
+			stderr += data.toString();
+		} );
+
+		process.on( 'close', ( code ) => {
+			resolve( { stdout, stderr, code } );
+		} );
+
+		process.on( 'error', ( err ) => {
+			reject( err );
+		} );
+
+		// Handle case where process is killed
+		process.on( 'exit', ( code, signal ) => {
+			if ( signal ) {
+				reject( new Error( `Process was killed with signal ${ signal }` ) );
+			}
+		} );
+
+		// Optional: Handle timeout
+		if ( options.timeout ) {
+			setTimeout( () => {
+				process.kill();
+				reject( new Error( `Process timed out after ${ options.timeout }ms` ) );
+			}, options.timeout );
+		}
+	} );
+}
+
+export { execAsync, ExecResult };

--- a/src/lib/mysql/versions.ts
+++ b/src/lib/mysql/versions.ts
@@ -1,0 +1,18 @@
+interface MySQLVersion {
+	mysqldBinPath: string; // path to mysqld binary
+	mysqlBinPath: string; // path to mysql binary
+	mysqladminBinPath: string; // path to mysqladmin binary
+	mysqlCnfTemplatePath: string; // my.cnf template using handlebars
+}
+
+const versions: Record< string, MySQLVersion > = {
+	'8.0.16': {
+		mysqldBinPath: '/Users/jeroenpfeil/Projects/mysql-binary/mysql-8.0.16/bin/darwin/bin/mysqld',
+		mysqlBinPath: '/Users/jeroenpfeil/Projects/mysql-binary/mysql-8.0.16/bin/darwin/bin/mysql',
+		mysqladminBinPath:
+			'/Users/jeroenpfeil/Projects/mysql-binary/mysql-8.0.16/bin/darwin/bin/mysqladmin',
+		mysqlCnfTemplatePath: '/Users/jeroenpfeil/Projects/mysql-binary/mysql-8.0.16/conf/my.cnf.hbs',
+	},
+};
+
+export default versions;

--- a/src/main-window.ts
+++ b/src/main-window.ts
@@ -26,6 +26,10 @@ function initializePortFinder( sites: SiteDetails[] ) {
 		if ( site.port ) {
 			portFinder.addUnavailablePort( site.port );
 		}
+
+		if ( site.mysql?.port ) {
+			portFinder.addUnavailablePort( site.mysql.port );
+		}
 	} );
 }
 

--- a/src/storage/paths.ts
+++ b/src/storage/paths.ts
@@ -9,6 +9,10 @@ export function getServerFilesPath(): string {
 	return path.join( getAppDataPath(), getAppName(), 'server-files' );
 }
 
+export function getMySQLPath(): string {
+	return path.join( getAppDataPath(), getAppName(), 'mysql' );
+}
+
 export const DEFAULT_SITE_PATH = path.join(
 	( process.env.E2E && process.env.E2E_HOME_PATH
 		? process.env.E2E_HOME_PATH

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -84,7 +84,6 @@ export async function loadUserData(): Promise< UserData > {
 
 export async function saveUserData( data: UserData ): Promise< void > {
 	const filePath = getUserDataFilePath();
-
 	const asString = JSON.stringify( toDiskFormat( data ), null, 2 ) + '\n';
 	await fs.promises.writeFile( filePath, asString, 'utf-8' );
 	console.log( `Saved user data to ${ sanitizeUserpath( filePath ) }` );
@@ -93,29 +92,32 @@ export async function saveUserData( data: UserData ): Promise< void > {
 function toDiskFormat( { sites, ...rest }: UserData ): PersistedUserData {
 	return {
 		version: 1,
-		sites: sites.map( ( { id, path, adminPassword, port, phpVersion, name, themeDetails } ) => {
-			// No object spreading allowed. TypeScript's structural typing is too permissive and
-			// will permit us to persist properties that aren't in the type definition.
-			// Add each property explicitly instead.
-			const persistedSiteDetails: PersistedUserData[ 'sites' ][ number ] = {
-				id,
-				name,
-				path,
-				adminPassword,
-				port,
-				phpVersion,
-				themeDetails: {
-					name: themeDetails?.name || '',
-					path: themeDetails?.path || '',
-					slug: themeDetails?.slug || '',
-					isBlockTheme: themeDetails?.isBlockTheme || false,
-					supportsWidgets: themeDetails?.supportsWidgets || false,
-					supportsMenus: themeDetails?.supportsMenus || false,
-				},
-			};
+		sites: sites.map(
+			( { id, path, adminPassword, port, phpVersion, name, themeDetails, mysql } ) => {
+				// No object spreading allowed. TypeScript's structural typing is too permissive and
+				// will permit us to persist properties that aren't in the type definition.
+				// Add each property explicitly instead.
+				const persistedSiteDetails: PersistedUserData[ 'sites' ][ number ] = {
+					id,
+					name,
+					path,
+					adminPassword,
+					port,
+					phpVersion,
+					themeDetails: {
+						name: themeDetails?.name || '',
+						path: themeDetails?.path || '',
+						slug: themeDetails?.slug || '',
+						isBlockTheme: themeDetails?.isBlockTheme || false,
+						supportsWidgets: themeDetails?.supportsWidgets || false,
+						supportsMenus: themeDetails?.supportsMenus || false,
+					},
+					mysql,
+				};
 
-			return persistedSiteDetails;
-		} ),
+				return persistedSiteDetails;
+			}
+		),
 		...rest,
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to #

## Proposed Changes

This is a PoC to see how easy/difficult it would be to add support for MySQL in Studio. The reason I created this experiment is because I think it would be valuable for folks who use Studio to pick the database of their choice. For now, I commented out SQLite support completely but we can implement a way to support both.

The way this is intended to work is that a user can select MySQL as their preferred database. Studio would then download pre-packaged MySQL binaries for the relevant OS (from our CDN). Once downloaded, Studio will manage an instance of MySQL for each site. 

When a new site is created, a new instance will be provisioned. The configuration for the instance (my.cnf) and the data files will be stored in the Studio app directory. Other provisioning steps include setting up db users, updating the wp-config.php file with correct DB credentials, and finally running a conventional WordPress installation via wp cli.

Studio manages the instances and ensures they are stopped when Studio exits or a site is stopped/deleted. Studio also cleans up the data directory when a site is removed.

### Todo
- Version management. I hardcoded paths to locally downloaded binaries for now but the idea is that these will be downloaded from our CDN.
- Fix MySQL issues in Playground
- Automatic login does not work, you need to manually login with username + password.

### Performance

MySQL uses some memory. Each running instance will use around 120MB of memory. If you want to run many sites simultaneously, things will slow down.

The query performance is similar to SQLite, though the more data the DB holds the better it performs vs SQLite. The bottleneck is Webassembly/Playground, which is significantly (~12x) slower than using PHP directly but this is irrespective of which DB is used.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Some [hardcoded paths](https://github.com/jeroenpf/studio/pull/1/files#diff-f01735204b3bc53528bb676f3171fcc66628d8fb9a55d1c8e06a46653fe87c15R10) need to be changed. DM me to get the binaries.
- Once the paths have been adjusted, you can run Studio using `nvm use && npm install && npm run start`
- Create one or more new sites.
- Run `ps aux | grep mysql` and you should see an instance of MySQL running for each created site. 

### Cleanup
There should not be a need to cleanup anything but if there were problems it is possible that the MySQL instances were not stopped correctly. You can run `ps aux | grep mysql` to see if there were any instances that weren't stopped. You can manually kill them if needed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
